### PR TITLE
preserve_sqlite_parameters

### DIFF
--- a/pandasql/sqldf.py
+++ b/pandasql/sqldf.py
@@ -70,7 +70,7 @@ def _write_table(tablename, df, conn):
     write_frame(df, name=tablename, con=conn, flavor='sqlite')
 
 
-def sqldf(q, env=dict(globals(),**locals()), inmemory=True):
+def sqldf(q, env, inmemory=True):
     """
     query pandas data frames using sql syntax
 

--- a/pandasql/sqldf.py
+++ b/pandasql/sqldf.py
@@ -70,13 +70,15 @@ def _write_table(tablename, df, conn):
     write_frame(df, name=tablename, con=conn, flavor='sqlite')
 
 
-def sqldf(q, env, inmemory=True):
+def sqldf(q, env=dict(globals(),**locals()), inmemory=True):
     """
     query pandas data frames using sql syntax
 
     q: a sql query using DataFrames as tables
     env: variable environment; locals() or globals() in your function
          allows sqldf to access the variables in your python environment
+         default is locals() otherwise globals()
+
     dbtype: memory/disk
         default is in memory; if not memory then it will be temporarily
         persisted to disk
@@ -115,7 +117,7 @@ def sqldf(q, env, inmemory=True):
         _write_table(table, df, conn)
 
     try:
-        result = frame_query(q, conn)
+        result = frame_query(q, conn, params=env)
     except:
         result = None
     finally:

--- a/pandasql/tests/tests.py
+++ b/pandasql/tests/tests.py
@@ -60,6 +60,18 @@ class PandaSQLTest(unittest.TestCase):
         result = sqldf(q, locals())
         self.assertEqual(len(result), 20)
 
+    def test_query_with_sqlite_parameters(self):
+        mylist = [ ('a',1), ('b',  2)]
+        myvariable=10
+
+        #my dico is : a personal definition, then locals() , then globals()
+        mydico=dict(globals(),**locals())
+        mydico['myanswer']=42
+
+        #sqlite will find parameters by name (:myvariable)
+        result = sqldf("SELECT  max(:myanswer),sum(:myvariable)  FROM mylist", mydico)
+        self.assertEqual(result.values.tolist(), [[42, 20]])
+
     def test_query_single_list(self):
 
         mylist = [i for i in range(10)]


### PR DESCRIPTION
Hello Greg,

its seems 'pandsql' omits to send parameters to sqlite motor, which would be nice to have.
Here is a separate fix proposal, and associated test.

mylist = [ ('a',1), ('b',  2)]
myanswer=42
result = sqldf("SELECT  *, :myanswer  FROM mylist",locals())
print (result)