### PR TITLE
exception treatment changed

### DIFF
--- a/pandasql/sqldf.py
+++ b/pandasql/sqldf.py
@@ -114,7 +114,7 @@ def sqldf(q, env, inmemory=True):
         result = read_sql(q, conn, index_col=None)
         if 'index' in result:
             del result['index']
-    except Exception, e:
+    except Exception:
         result = None
     finally:
         conn.close()


### PR DESCRIPTION
When I try to import pandasql the system prints this error:

``` python
from pandasql import sqldf
  File "/opt/python34/lib/python3.4/site-packages/pandasql/__init__.py", line 1, in <module>
    from .sqldf import sqldf
  File "/opt/python34/lib/python3.4/site-packages/pandasql/sqldf.py", line 117
    except Exception, e:
                    ^
SyntaxError: invalid syntax
```

If I remove the ', e', the library works well.

Version INSTALLED: 0.6.1 (latest)
