### PR TITLE
Add a user defined regexp function when initialising sqlite connection

### DIFF
--- a/pandasql/sqldf.py
+++ b/pandasql/sqldf.py
@@ -90,9 +90,16 @@ class PandaSQL:
     def _init_connection(self, conn):
         if self.engine.name == 'postgresql':
             conn.execute('set search_path to pg_temp')
+        elif self.engine.name == 'sqlite':
+            conn.connection.connection.create_function("REGEXP", 2, regex)
 
     def _set_text_factory(self, dbapi_con, connection_record):
         dbapi_con.text_factory = str
+
+
+def regex(expr, item):
+    reg = re.compile(expr)
+    return reg.match(item) is not None
 
 
 def get_outer_frame_variables():


### PR DESCRIPTION
Hi, I realised that by default I could not use the REGEXP keyword/function of sqlite because it requires a user-defined function to work. This patch solves the problem and allows to do:

```
pysqldf("""
    SELECT count(*) 
    FROM tweets
        WHERE NOT date REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
    LIMIT 10
""") 
```

It's a fairly simple patch, let me know what you think or if it requires any changes.